### PR TITLE
Better support for long running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Change Log
 
-All notable changes to the "python-autotest" extension will be documented in this file.
-
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+Test On Save follows semantic versioning.
+This means:
+* A change in the major version implies a breaking change, and you probably have to update your settings.json.
+* A change in the minor version implies a new feature, without breaking compatibility.
+* A change in the patch version implies a bug fix.
 
 ## [Unreleased]
+
+### Changed
+- Better support for longer running test suites:
+    - stream the output to the "Test On Save" output channel instead of waiting for the tests to finish
+      before showing the output
+    - ignore file saves while a test is already running
+- Clear the output channel before each run
+
+## [1.0.0] - 2021-11-21
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ The following open TODOs and known issues exists:
 
 ## Release Notes
 
-### 1.0.0
-
-Initial release of Test On Save.
-
+See the [changelog](https://marketplace.visualstudio.com/items/andifin.testonsave/changelog) for details.
 
 ## Attributions
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,17 +83,16 @@ class TestOnSave {
 			return;
 		}
 		this._statusUpdate("$(loading~spin) Tests");
-		exec(this._testCommand, { cwd: workspaceFolderPath }, (error, stdout, stderr) => {
-			this._outputChannel.append(stdout);
-			this._outputChannel.append(stderr);
-			if (error) {
-				this._outputChannel.append(error.message);
-				this._statusUpdate('$(testing-failed-icon) Tests');
-			}
-			else {
-				this._statusUpdate('$(testing-passed-icon) Tests');
-			}
-			this._statusBarIcon.show();
+		let child = exec(this._testCommand, { cwd: workspaceFolderPath });
+		if (child.stdout && child.stderr) {
+			child.stdout.on('data', data => { this._outputChannel.append(data); });
+			child.stderr.on('data', data => { this._outputChannel.append(data); });
+		}
+		child.on('error', e => {
+			this._outputChannel.append(e.message);
+		});
+		child.on('exit', code => {
+			code === 0 ? this._statusUpdate('$(testing-passed-icon) Tests') : this._statusUpdate('$(testing-failed-icon) Tests');
 		});
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
 
-	var extension = new TestOnSave(context);
+	const extension = new TestOnSave(context);
 
 	vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
 		extension.runTests(document);
@@ -14,6 +14,7 @@ class TestOnSave {
 	private _testCommand: any = null;
 	private _isEnabled: any = false;
 	private _languageId: any = "any";
+	private _running: boolean = false;
 	private _outputChannel: vscode.OutputChannel;
 	private _statusBarIcon: vscode.StatusBarItem;
 
@@ -71,10 +72,12 @@ class TestOnSave {
 	}
 
 	public runTests(document: vscode.TextDocument) {
-		if (!this._isRelevantFile(document) || !this._isEnabled) {
+		if (!this._isEnabled || this._running || !this._isRelevantFile(document)) {
+			// TestOnSave is disabled, or we are already running tests, or the file is not relevant.
 			return;
 		}
 		if (this._testCommand === null || this._testCommand.trim() === "") {
+			// No test command configured or empty.
 			vscode.window.showErrorMessage('No test command configured');
 			return;
 		}
@@ -82,6 +85,8 @@ class TestOnSave {
 		if (workspaceFolderPath === undefined) {
 			return;
 		}
+		this._outputChannel.clear();
+		this._running = true;
 		this._statusUpdate("$(loading~spin) Tests");
 		let child = exec(this._testCommand, { cwd: workspaceFolderPath });
 		if (child.stdout && child.stderr) {
@@ -93,6 +98,7 @@ class TestOnSave {
 		});
 		child.on('exit', code => {
 			code === 0 ? this._statusUpdate('$(testing-passed-icon) Tests') : this._statusUpdate('$(testing-failed-icon) Tests');
+			this._running = false;
 		});
 	}
 }


### PR DESCRIPTION
* Stream output to the console rather than waiting for the child process to finish and then dump all the output
* Ignore file saves while a test is already running
* Clear the console before each tests for more clarity