### PR TITLE
Map exit codes to status icons for fail/pass/error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This means:
 * A change in the minor version implies a new feature, without breaking compatibility.
 * A change in the patch version implies a bug fix.
 
-## [Unreleased]
+## [1.1.0] - 2022-04-18
 
 ### Changed
 - Better support for longer running test suites:
@@ -14,6 +14,8 @@ This means:
       before showing the output
     - ignore file saves while a test is already running
 - Clear the output channel before each run
+- Add a separate icon for errors during the test run
+- Add configuration options to map exit codes to status icons
 
 ## [1.0.0] - 2021-11-21
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This extension will automatically run them for you when you save a file!
 * Language independent - command to run tests can be set through ``settings.json``
 * Can be enabled/disabled through ``settings.json`` or by clicking the status bar icon
 * Runs discretely in the background - no annoying popups, only red or green status bar icon displaying last test result
+* Exit codes can be mapped to status icons for passing, failed, and errored tests
 
 
 ## Demo
@@ -24,6 +25,9 @@ This extension contributes the following settings:
 * `testOnSave.enabled`: Enable/disable this extension
 * `testOnSave.testCommand`: Command to run tests. Any non-zero exit code is treated as failing tests.
 * `testOnSave.languageId`: Only trigger tests when a file of this language is saved. Set to "any" to always run tests after saving.
+* `testOnSave.exitCodePass`: Exit code(s) that are considered as a passing test suite. Defaults to 0.
+* `testOnSave.exitCodeFail`: Exit code(s) that are considered as a failing test suite. Defaults to non-zero.
+* `testOnSave.exitCodeError`: Exit code(s) that are considered as errors when running the tests. Not used by default.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "Run tests automatically on save.",
 	"license": "SEE LICENSE IN LICENSE",
 	"icon": "images/logo.png",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"engines": {
 		"vscode": "^1.62.0"
 	},
@@ -40,6 +40,21 @@
 						"type": "string",
 						"description": "Only files with this language id trigger the test command. Use 'any' to trigger independent of the language.",
 						"default": "any"
+					},
+					"testOnSave.exitCodePass": {
+						"type": "string",
+						"description": "Exit code(s) that are considered as a passing test suite. Defaults to 0. Separate multiple exit codes by comma. You can also use ranges. Example: '0,1,2-4'",
+						"default": "0"
+					},
+					"testOnSave.exitCodeFail": {
+						"type": "string",
+						"description": "Exit code(s) that are considered as a failing test suite. Defaults to 0-999. Separate multiple exit codes by comma. You can also use ranges. Example: '0,1,2-4'",
+						"default": "0-999"
+					},
+					"testOnSave.exitCodeError": {
+						"type": "string",
+						"description": "Exit code(s) that are considered as errors when running the tests. Not used by default. Separate multiple exit codes by comma. You can also use ranges. Example: '0,1,2-4'",
+						"default": null
 					}
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,6 +115,7 @@ class TestOnSave {
 		} else if (this._exitCodeError.has(exitCode)) {
 			return '$(testing-error-icon)';
 		} else {
+			this._outputChannel.append(`Unknown exit code: ${exitCode} - cannot determine status icon to display.\n`);
 			return '$(question)';
 		}
 	}
@@ -142,7 +143,10 @@ class TestOnSave {
 			child.stderr.on('data', data => { this._outputChannel.append(data); });
 		}
 		child.on('error', e => {
+			this._outputChannel.append("Error while calling test command:\n");
 			this._outputChannel.append(e.message);
+			this._statusUpdate('$(extensions-warning-message) Tests');
+			this._running = false;
 		});
 		child.on('exit', code => {
 			let statusIcon = '$(question)';


### PR DESCRIPTION
This introduces three new configuration properties:
* `testOnSave.exitCodePass`: Exit code(s) that are considered as a passing test suite. Defaults to 0.
* `testOnSave.exitCodeFail`: Exit code(s) that are considered as a failing test suite. Defaults to non-zero.
* `testOnSave.exitCodeError`: Exit code(s) that are considered as errors when running the tests. Not used by default.

The new icon for testing errors is the standard `testing-error-icon` of VS code, to keep consistency with the normal test explorer icons.

Closes #2 